### PR TITLE
Fix for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,13 @@ sudo pacman -S gcc make sdl2
 If your Linux distribution is immutable (such as Fedora Atomic, Bazzite or SteamOS), you can use [Distrobox](https://distrobox.it/). 
 
 #### Windows
+Visual Studio 2022 or later with the C++ and C development tools installed
 
-Visual Studio 2022 or later with the C++ and C development tools installed and vcpkg integration is required.
+But since those tools doens't have SDL2, do this following command:
+
+```bash
+vcpkg integrate install
+```
 
 ### Compiling 
 Simply run the following commands inside a personal directory. 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "4f8fe05871555c1798dbcb1957d0d595e94f7b57",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "dependencies": [
     "sdl2"
   ]
+
 }


### PR DESCRIPTION
Well visual studio 2022 tools dont contain SDL2 but its possible with vcpkg so i fixed the vcpkg thing and uhhhhh idk